### PR TITLE
Support additional stages.  Only staging/production are supported.

### DIFF
--- a/lib/capistrano/gitflow.rb
+++ b/lib/capistrano/gitflow.rb
@@ -75,7 +75,7 @@ Please make sure you have pulled and pushed all code before deploying:
               # make sure we have any other deployment tags that have been pushed by others so our auto-increment code doesn't create conflicting tags
               `git fetch`
 
-              send "tag_#{stage}"
+              send "tag_#{stage}" if respond_to?(stage)
 
               system "git push --tags origin #{local_branch}"
               if $? != 0


### PR DESCRIPTION
After making the standard capistrano changes to support a new stage "qa", I am now receiving an error (below) when running `cap qa deploy`.  This commit removes the error, providing basic support for other stages.  I am interested in supporting the workflow for other stages too.

```
gems/capistrano-2.5.19/lib/capistrano/configuration/namespaces.rb:188:in `method_missing': 
undefined method `tag_qa' for #<Capistrano::Configuration::Namespaces::Namespace:0x10055a478> (NoMethodError)
from /Users/matt/.rvm/gems/ree-1.8.7-2010.02@toura_map/gems/capistrano-gitflow-1.4.1/lib/capistrano/gitflow.rb:78:in `send'
from /Users/matt/.rvm/gems/ree-1.8.7-2010.02@toura_map/gems/capistrano-gitflow-1.4.1/lib/capistrano/gitflow.rb:78:in `load_into'
```

capistrano-gitflow expects a cap task to exist named `tag_qa`.
