### PR TITLE
Updated gem to support capistrano 3 ( and kept support for capistrano 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,4 +74,3 @@ tags
 .rbenv-version
 .ruby-version
 Gemfile.lock
-/nbproject/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,77 @@
+# rcov generated
+coverage
+coverage.data
+
+# rdoc generated
 rdoc
+
+# yard generated
+doc
+.yardoc
+
+# bundler
+.bundle
+
+# jeweler generated
 pkg
+
+# For TextMate
+*.tmproj
+tmtags
+
+# For emacs:
+*~
+\#*
+.\#*
+
+# For vim:
+*.swp
+
+# For redcar:
+.redcar
+
+# For rubinius:
+*.rbc
+/nbproject/private/
+
+/tmp/
+
+
+# Logs and databases #
+######################
+*.log
+*.sql
+*.sqlite
+
+# OS generated files #
+######################
+*~
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+Icon?
+ehthumbs.db
+Thumbs.db
+.rvmrc
+s.rbx/
+.bundle/
+*.gem
+.idea/
+.rvmrc
+*.swp
+log/*.log
+pkg/
+spec/dummy/db/*.sqlite3
+spec/dummy/log/*.log
+spec/dummy/tmp/
+gemfiles
+coverage
+tags
+/nbproject/
+/.git-rewrite/
+.rbenv-version
+.ruby-version
+Gemfile.lock
+/nbproject/

--- a/capistrano-gitflow.gemspec
+++ b/capistrano-gitflow.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Joshua Nichols"]
-  s.date =Date.today
+  s.date =%q{2011-04-07}
   s.description = %q{Capistrano recipe for a deployment workflow based on git tags}
   s.email = %q{josh@technicalpickles.com}
   s.extra_rdoc_files = [

--- a/capistrano-gitflow.gemspec
+++ b/capistrano-gitflow.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Joshua Nichols"]
-  s.date = %q{2011-04-07}
+  s.date =Date.today
   s.description = %q{Capistrano recipe for a deployment workflow based on git tags}
   s.email = %q{josh@technicalpickles.com}
   s.extra_rdoc_files = [

--- a/capistrano-gitflow.gemspec
+++ b/capistrano-gitflow.gemspec
@@ -15,27 +15,13 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = [
     "README.rdoc"
   ]
-  s.files = [
-    ".document",
-    "README.rdoc",
-    "Rakefile",
-    "VERSION",
-    "capistrano-gitflow.gemspec",
-    "lib/capistrano/gitflow.rb",
-    "lib/capistrano/gitflow/natcmp.rb",
-    "recipes/gitflow_recipes.rb",
-    "spec/gitflow_spec.rb",
-    "spec/spec.opts",
-    "spec/spec_helper.rb"
-  ]
+  s.files = `git ls-files`.split("\n")
+  
   s.homepage = %q{http://github.com/technicalpickles/capistrano-gitflow}
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.7}
   s.summary = %q{Capistrano recipe for a deployment workflow based on git tags}
-  s.test_files = [
-    "spec/gitflow_spec.rb",
-    "spec/spec_helper.rb"
-  ]
+  s.test_files =s.files.grep(/^(spec)/)
 
   if s.respond_to? :specification_version then
     current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION

--- a/lib/capistrano/gitflow/helpers/helper.rb
+++ b/lib/capistrano/gitflow/helpers/helper.rb
@@ -4,7 +4,7 @@ module CapistranoGitFlow
       
     def gitflow_stage
       original_stage = fetch(:stage)
-      original_stage.include?(":") ? original_stage.split(':').reverse[0] : original_stage
+      original_stage.to_s.include?(":") ? original_stage.split(':').reverse[0] : original_stage
     end
     
     def gitflow_using_cap3?

--- a/lib/capistrano/gitflow/legacy/.LCKgitflow.rb~
+++ b/lib/capistrano/gitflow/legacy/.LCKgitflow.rb~
@@ -1,1 +1,0 @@
-/home/raul/workspace/github/capistrano-gitflow/lib/capistrano/gitflow/recipes/gitflow.rb

--- a/lib/capistrano/tasks/gitflow.rb
+++ b/lib/capistrano/tasks/gitflow.rb
@@ -25,7 +25,7 @@ namespace :gitflow do
     gitflow_tag_production
   end
 
-  gitflow_callbacks
+  gitflow_callbacks unless defined?(Sinatra)
 end
 
 namespace :deploy do


### PR DESCRIPTION
Hello, 
  I have modified the gem to work with capistrano 3, and refactored a bit the code to keep it more DRY. This way would be easier when adding support to new versions since you will only have to modify the helper module. 

I have tested this with capistrano 2.15.4 and capistrano 3, including latest version and it seems to work ok. 

Let me know what you think about it. Thank you very much. 
